### PR TITLE
Fix enable if on derangement function inside discreate/include/derang…

### DIFF
--- a/discrete/include/derangement.hxx
+++ b/discrete/include/derangement.hxx
@@ -2,7 +2,7 @@
 #include <type_traits>
 
 template <typename T, typename Ret = uint64_t>
-std::enable_if_t<std::is_arithmetic_v<T>>
+std::enable_if<std::is_arithmetic_v<T>, Ret>
 derangement(T n){
   if (!n) return 1;
   if (n==1) return 0;


### PR DESCRIPTION
…ement.hxx

The function should return as uint64_t or defined user Ret variable. My previous device broken, my account is lost because I enabled 2FA. I am trying to request access for my account via email, hopefully it will be approved. After that, I can accept this pull request